### PR TITLE
Made xbundle compatible with python 3

### DIFF
--- a/bin/xbundle_convert
+++ b/bin/xbundle_convert
@@ -30,6 +30,7 @@ from xbundle import XBundle, run_tests
 
 # pylint: disable=star-args
 
+
 def main():
     """
     Convert between OLX and xbundle XML formats.
@@ -52,19 +53,21 @@ def main():
     input_path = args['<input>']
     output_path = args['<output>']
     if input_path.endswith('.xml'):
-        print "Converting xbundle '{0}' to edX directory '{1}'".format(
+        print("Converting xbundle '{0}' to edX directory '{1}'".format(
             input_path, output_path)
+        )
         bundle.load(input_path)
         bundle.export_to_directory(output_path)
-        print "done"
+        print("done")
     elif output_path.endswith('.xml'):
-        print "Converting edX directory '{0}' to xbundle '{1}'".format(
+        print("Converting edX directory '{0}' to xbundle '{1}'".format(
             input_path, output_path)
+        )
         bundle.import_from_directory(input_path)
         bundle.save(output_path)
-        print "done"
+        print("done")
     else:
-        print "Invalid input; run with --help for more info."
+        print("Invalid input; run with --help for more info.")
         sys.exit(1)
 
 if __name__ == '__main__':

--- a/xbundle/__init__.py
+++ b/xbundle/__init__.py
@@ -177,7 +177,7 @@ class XBundle(object):
                 elem = etree.SubElement(policies, basename(
                     filename).replace('_', '').replace('.json', ''))
                 with open(filename) as data:
-                    elem.text = data.read().decode('utf-8')
+                    elem.text = unicode(data.read(), encoding='utf-8')
             self.add_policies(policies)
 
         # Load "about" files.

--- a/xbundle/__init__.py
+++ b/xbundle/__init__.py
@@ -26,7 +26,7 @@ import subprocess
 from os.path import join, exists, basename
 
 from lxml import etree
-
+import unicodedata
 log = logging.getLogger()  # pylint: disable=invalid-name
 logging.basicConfig()
 log.setLevel(logging.DEBUG)
@@ -124,7 +124,10 @@ class XBundle(object):
         abfile.text = filedata
         # Unicode characters in the "about" HTML file were causing
         # the lxml package to break.
-        abfile.text = filedata.decode('utf-8')
+        if not isinstance(filedata, str):
+            abfile.text = filedata.decode('utf-8')
+        else:
+            abfile.text = filedata
 
     def load(self, filename):
         """
@@ -183,8 +186,9 @@ class XBundle(object):
         # Load "about" files.
         for afn in glob(join(path, 'about/*')):
             try:
-                with open(afn) as data:
-                    self.add_about_file(basename(afn), data.read())
+                with open(afn, "rb") as data:
+                    self.add_about_file(
+                        basename(afn), data.read().decode("utf-8"))
             except ValueError as err:
                 log.warning("Failed to add file %s, error=%s", afn, err)
 
@@ -408,7 +412,7 @@ class XBundle(object):
             for k in pxml:
                 filename = POLICY_TAG_MAP.get(k.tag, k.tag) + '.json'
                 # Write out content to policy directory file.
-                with open(join(path, filename), 'w') as output:
+                with open(join(path, filename), 'wb') as output:
                     output.write(k.text.encode('utf-8'))
 
         adir = mkdir(join(self.path, 'about'))
@@ -418,8 +422,12 @@ class XBundle(object):
                 # Moved "if" statement after the "open" statement, so we
                 # no longer create zero-byte files here.
                 if fxml.text not in (None, ""):
-                    with open(join(adir, filename), 'w') as output:
-                        output.write(fxml.text)
+                    try:
+                        to_write = fxml.text.encode("utf-8")
+                    except UnicodeEncodeError:
+                        to_write = fxml.text
+                    with open(join(adir, filename), 'wb') as output:
+                        output.write(to_write)
             except IOError as err:
                 log.error(
                     'failed to write about file %s, error %s',
@@ -497,11 +505,20 @@ class XBundle(object):
             '/': '__',
             '&': 'and',
         }
+
         for key, val in replacements.items():
             for char in key:
-                display_name = display_name.replace(char, val)
+                char_bytes = unicodedata.normalize('NFKD', char).encode('ascii', 'ignore')
+                val_bytes = unicodedata.normalize('NFKD', val).encode('ascii', 'ignore')
+                display_name = display_name.replace(char_bytes, val_bytes)
+                
         if name and display_name in self.urlnames and parent:
-            display_name += '_' + parent
+            display_name = "{0}_{1}".format(display_name, parent)
+            try:
+                # Sometimes it's bytes, sometimes a string...
+                display_name = display_name.decode("utf-8")
+            except AttributeError:
+                pass
         while display_name in self.urlnames:
             key = re.match('(.+?)([0-9]*)$', display_name)
             display_name, idx = key.groups()
@@ -580,8 +597,8 @@ def pp_xml(xml):
         log.warning("xmllint not found on system: %s", ex)
         xml = etree.tostring(xml, pretty_print=True)
 
-    if xml.startswith('<?xml '):
-        xml = xml.split('\n', 1)[1]
+    if xml.startswith(b'<?xml '):
+        xml = xml.decode('utf-8').split('\n', 1)[1]
     return xml
 
 

--- a/xbundle/__init__.py
+++ b/xbundle/__init__.py
@@ -600,7 +600,7 @@ def run_tests():  # pragma: no cover
             """
             Test import/export cycle.
             """
-            print "Testing XBundle round trip import -> export"
+            print("Testing XBundle round trip import -> export")
             bundle = XBundle()
             cxmls = """
 <course semester="2013_Spring" course="mitx.01">
@@ -640,10 +640,10 @@ def run_tests():  # pragma: no cover
             xbreloaded = str(xb2)
 
             if not xbin == xbreloaded:
-                print "xbin"
-                print xbin
-                print "xbreloaded"
-                print xbreloaded
+                print("xbin")
+                print(xbin)
+                print("xbreloaded")
+                print(xbreloaded)
 
             self.assertEqual(xbin, xbreloaded)
 

--- a/xbundle/__init__.py
+++ b/xbundle/__init__.py
@@ -176,8 +176,8 @@ class XBundle(object):
                     continue
                 elem = etree.SubElement(policies, basename(
                     filename).replace('_', '').replace('.json', ''))
-                with open(filename) as data:
-                    elem.text = unicode(data.read(), encoding='utf-8')
+                with open(filename, "rb") as data:
+                    elem.text = data.read().decode('utf-8')
             self.add_policies(policies)
 
         # Load "about" files.


### PR DESCRIPTION
Hi

In this PR I made xbundle compatible with python 3. Previously test suit was not working on python 3. Now it is working on both python version 2.7 and 3

@muzaffaryousaf @symbolist
